### PR TITLE
Allow user to opt-out and delete their own information if they do not wish to have an account with gitpay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+composer.lock
+node_modules
+vendor

--- a/deleteuser.php
+++ b/deleteuser.php
@@ -1,0 +1,21 @@
+<?php
+
+// includes
+require_once 'vendor/autoload.php';
+@include_once('server.php');
+include_once('dbconfig.php');
+include_once('github.php');
+include_once('functions.php');
+
+// DB
+$fallbackdb = 'ghtorrent';
+$conn = new PDO("mysql:host=$host;dbname=$db", $username, $password);
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$connfb = new PDO("mysql:host=$host;dbname=$fallbackdb", $username, $password);
+$connfb->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+if (isset($_SESSION['loggedin']) && $_SESSION['loggedin'] === 'true') {
+	deleteUser($_SESSION['login'], $conn);
+}
+
+?>

--- a/functions.php
+++ b/functions.php
@@ -106,8 +106,8 @@ function deleteUser($nick, $conn = null, $client = null) {
     $stmt = $conn->prepare($sql);
     $stmt->execute();
 
-    $sql = "delete from preferences where webid = '$nick'; ";
-    $stmt = $conn->prepare($sql);
+    $stmt = $conn->prepare('delete from preferences where webid = :nick');
+    $stmt = $conn->bindParam(':nick', $nick, PDO::PARAM_STR, 255);
     $stmt->execute();
   }
 }

--- a/functions.php
+++ b/functions.php
@@ -100,6 +100,18 @@ function getUser($nick, $conn = null, $client = null) {
   return $user;
 }
 
+function deleteUser($nick, $conn = null, $client = null) {
+  if ($conn) {
+    $sql = "delete from users where login = '$nick'; ";
+    $stmt = $conn->prepare($sql);
+    $stmt->execute();
+
+    $sql = "delete from preferences where webid = '$nick'; ";
+    $stmt = $conn->prepare($sql);
+    $stmt->execute();
+  }
+}
+
 function getActive($nick, $conn) {
   $sql = "select * from preferences where webid = '$nick'; ";
   $active = select($sql, $conn);

--- a/functions.php
+++ b/functions.php
@@ -102,8 +102,8 @@ function getUser($nick, $conn = null, $client = null) {
 
 function deleteUser($nick, $conn = null, $client = null) {
   if ($conn) {
-    $sql = "delete from users where login = '$nick'; ";
-    $stmt = $conn->prepare($sql);
+    $stmt = $conn->prepare('delete from users where login = :nick');
+    $stmt = $conn->bindParam(':nick', $nick, PDO::PARAM_STR, 255);
     $stmt->execute();
 
     $stmt = $conn->prepare('delete from preferences where webid = :nick');

--- a/user.php
+++ b/user.php
@@ -239,7 +239,8 @@ limitations under the License
           <h3>Gitpay Ranking <?php  if (isset($ledger) && $ledger['balance']) echo "<br><a class='mdl-color-text--blue-800' target='_blank' href='w/?walletURI=https:%2F%2Fgitpay.databox.me%2FPublic%2F.wallet%2Fgithub.com%2Flinkeddata%2FSoLiD%2Fwallet%23this&user=". urlencode($preferredURI) ."'>$ledger[balance] bits</a> - <a href='$project'>Project</a>" ; ?></h3>
         -->
 
-        <?php if( isset($_SESSION['loggedin']) && $_SESSION['loggedin'] === 'true' && $_SESSION['login'] === $nick  ) {
+        <?php
+        if( isset($_SESSION['loggedin']) && $_SESSION['loggedin'] === 'true' && $_SESSION['login'] === $nick  ) {
           echo "<h3>Welcome, " . $nick .  "<h3>";
         } else {
           if (!empty($active) && $active['active'] == 1 ) {
@@ -255,8 +256,9 @@ limitations under the License
         <h3>Info</h3>
         <hr>
 
-        <?php if( isset($_SESSION['loggedin']) && $_SESSION['loggedin'] === 'true' && $_SESSION['login'] === $nick  ) {
-          echo "<h4>Congratulations, you have logged in.  You have earnt one reputation point.  Account management and more <a target=\"_blank\" href=\"https://melvincarvalho.gitbooks.io/gitpay/content/\">features</a> coming soon.<h4><hr>";
+        <?php
+        if( isset($_SESSION['loggedin']) && $_SESSION['loggedin'] === 'true' && $_SESSION['login'] === $nick  ) {
+          echo "<h4>Congratulations, you have logged in.  You have earnt one reputation point.  Account management and more <a target=\"_blank\" href=\"https://melvincarvalho.gitbooks.io/gitpay/content/\">features</a> coming soon.<h4><h4>If you wish to opt-out of gitpay, click here: <a href='/deleteuser.php'>Remove my account</a></h4><hr>";
 
           ?>
           <h3>Donations</h3>


### PR DESCRIPTION
Hi,

I have been trying to get a hold of someone at gitpay to have my account removed so that it can also be purged from Google search.

My initial contact was on Dec. 21st, 2016 and I have not heard back since despite two additional attempts.

Gitpay seems to create an "unactivated" account for anyone that happens to click on the URI and then upon authenticating via github oath, it then creates an account but does not allow you in anyway to manage your account or even delete your own account if you do not wish to have a gitpay account.

I imagine that many people like myself have attempted to "activate" their account simply for the purpose of deleting their own account. Therefore now they can without having to contact anyone.

So I figured that I can simply create a pull request for an easy way to simply delete all information from the database that relates to their particular account using their logged in session information. 

This is extremely useful for many as your website states: "Account management and more features coming soon." and it is not easy to get in contact with anyone at gitpay.

I also noticed that in the database, there's a flag `deleted` which is either 0 or 1. This hints to me that if an account is deleted, the information may still be there. I discourage you (gitpay) from doing this since if an account is considered deleted, then it must be purged from the database. You should generally not continue to store one's information after they have deleted their account.

I understand that this may be useful in case your system re-creates an account for them later, but this should probably be handled by another table of previously deleted github uris.

Emails, names and so forth should be purged upon delete.

This resolves issue #5 .